### PR TITLE
Enable Offer To Cluster

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,15 +1,149 @@
 package cluster
 
-import "github.com/lirm/aeron-go/aeron/idlestrategy"
+import (
+	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/idlestrategy"
+	"github.com/lirm/aeron-go/cluster/codecs"
+)
 
 type Cluster interface {
+	/**
+	 * Position the log has reached in bytes as of the current message.
+	 *
+	 * @return position the log has reached in bytes as of the current message.
+	 */
 	LogPosition() int64
+
+	/**
+	 * The unique id for the hosting member of the cluster. Useful only for debugging purposes.
+	 *
+	 * @return unique id for the hosting member of the cluster.
+	 */
 	MemberId() int32
+
+	/**
+	 * The role the cluster node is playing.
+	 *
+	 * @return the role the cluster node is playing.
+	 */
 	Role() Role
+
+	/**
+	 * Cluster time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
+	 *
+	 * @return time as {@link #timeUnit()}s since 1 Jan 1970 UTC.
+	 */
 	Time() int64
+
+	/**
+	 * The unit of time applied when timestamping and {@link #time()} operations.
+	 *
+	 * @return the unit of time applied when timestamping and {@link #time()} operations.
+	 */
+	TimeUnit() codecs.ClusterTimeUnitEnum
+
+	/**
+	 * {@link IdleStrategy} which should be used by the service when it experiences back-pressure on egress,
+	 * closing sessions, making timer requests, or any long-running actions.
+	 *
+	 * @return the {@link IdleStrategy} which should be used by the service when it experiences back-pressure.
+	 */
 	IdleStrategy() idlestrategy.Idler
 
-	// ScheduleTimer schedules a timer for a given deadline
+	/**
+	 * Schedule a timer for a given deadline and provide a correlation id to identify the timer when it expires or
+	 * for cancellation. This action is asynchronous and will race with the timer expiring.
+	 * <p>
+	 * If the correlationId is for an existing scheduled timer then it will be rescheduled to the new deadline. However,
+	 * it is best to generate correl~~ationIds in a monotonic fashion and be aware of potential clashes with other
+	 * services in the same cluster. Service isolation can be achieved by using the upper bits for service id.
+	 * <p>
+	 * Timers should only be scheduled or cancelled in the context of processing a
+	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
+	 * {@link ClusteredService#onTimerEvent(long, long)},
+	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
+	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
+	 * If applied to other events then they are not guaranteed to be reliable.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds.
+	 *
+	 * <pre>{@code
+	 * private Cluster cluster;
+	 * // Lines omitted...
+	 *
+	 * cluster.idleStrategy().reset();
+	 * while (!cluster.scheduleTimer(correlationId, deadline))
+	 * {
+	 *     cluster.idleStrategy().idle();
+	 * }
+	 * }</pre>
+	 *
+	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	 * shutdown if required.
+	 *
+	 * @param correlationId to identify the timer when it expires. {@link Long#MAX_VALUE} not supported.
+	 * @param deadline      time after which the timer will fire. {@link Long#MAX_VALUE} not supported.
+	 * @return true if the event to schedule a timer request has been sent or false if back-pressure is applied.
+	 * @see #cancelTimer(long)
+	 */
 	ScheduleTimer(correlationId int64, deadline int64) bool
+
+	/**
+	 * Cancel a previously scheduled timer. This action is asynchronous and will race with the timer expiring.
+	 * <p>
+	 * Timers should only be scheduled or cancelled in the context of processing a
+	 * {@link ClusteredService#onSessionMessage(ClientSession, long, DirectBuffer, int, int, Header)},
+	 * {@link ClusteredService#onTimerEvent(long, long)},
+	 * {@link ClusteredService#onSessionOpen(ClientSession, long)}, or
+	 * {@link ClusteredService#onSessionClose(ClientSession, long, CloseReason)}.
+	 * If applied to other events then they are not guaranteed to be reliable.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds, see {@link
+	 * io.aeron.cluster.service.Cluster#scheduleTimer(long, long)} for an example.
+	 *
+	 * @param correlationId for the timer provided when it was scheduled. {@link Long#MAX_VALUE} not supported.
+	 * @return true if the event to cancel request has been sent or false if back-pressure is applied.
+	 * @see #scheduleTimer(long, long)
+	 */
 	CancelTimer(correlationId int64) bool
+
+	/**
+	 * Offer a message as ingress to the cluster for sequencing. This will happen efficiently over IPC to the
+	 * consensus module and have the cluster session of as the negative value of the
+	 * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SERVICE_ID_PROP_NAME}.
+	 * <p>
+	 * Callers of this method should loop until the method succeeds.
+	 *
+	 * <pre>{@code
+	 * private Cluster cluster;
+	 * // Lines omitted...
+	 *
+	 * cluster.idleStrategy().reset();
+	 * do
+	 * {
+	 *     final long position = cluster.offer(buffer, offset, length);
+	 *     if (position > 0)
+	 *     {
+	 *         break;
+	 *     }
+	 *     else if (Publication.ADMIN_ACTION != position || Publication.BACK_PRESSURED != position)
+	 *     {
+	 *         throw new ClusterException("Internal offer failed: " + position);
+	 *     }
+	 *
+	 *     cluster.idleStrategy.idle();
+	 * }
+	 * while (true);
+	 * }</pre>
+	 *
+	 * The cluster's idle strategy must be used in the body of the loop to allow for the clustered service to be
+	 * shutdown if required.
+	 *
+	 * @param buffer containing the message to be offered.
+	 * @param offset in the buffer at which the encoded message begins.
+	 * @param length in the buffer of the encoded message.
+	 * @return positive value if successful.
+	 * @see io.aeron.Publication#offer(DirectBuffer, int, int)
+	 */
+	Offer(*atomic.Buffer, int32, int32) int64
 }

--- a/cluster/clustered_service.go
+++ b/cluster/clustered_service.go
@@ -8,16 +8,50 @@ import (
 )
 
 type ClusteredService interface {
+	/**
+	 * Start event for the service where the service can perform any initialisation required and load snapshot state.
+	 * The snapshot image can be null if no previous snapshot exists.
+	 * <p>
+	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
+	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
+	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)}, especially when polling the {@link Image} returns 0.
+	 *
+	 * @param cluster       with which the service can interact.
+	 * @param snapshotImage from which the service can load its archived state which can be null when no snapshot.
+	 */
 	OnStart(cluster Cluster, image aeron.Image)
 
+	/**
+	 * A session has been opened for a client to the cluster.
+	 *
+	 * @param session   for the client which have been opened.
+	 * @param timestamp at which the session was opened.
+	 */
 	OnSessionOpen(session ClientSession, timestamp int64)
 
+	/**
+	 * A session has been closed for a client to the cluster.
+	 *
+	 * @param session     that has been closed.
+	 * @param timestamp   at which the session was closed.
+	 * @param closeReason the session was closed.
+	 */
 	OnSessionClose(
 		session ClientSession,
 		timestamp int64,
 		closeReason codecs.CloseReasonEnum,
 	)
 
+	/**
+	 * A message has been received to be processed by a clustered service.
+	 *
+	 * @param session   for the client which sent the message. This can be null if the client was a service.
+	 * @param timestamp for when the message was received.
+	 * @param buffer    containing the message.
+	 * @param offset    in the buffer at which the message is encoded.
+	 * @param length    of the encoded message.
+	 * @param header    aeron header for the incoming message.
+	 */
 	OnSessionMessage(
 		session ClientSession,
 		timestamp int64,
@@ -27,14 +61,52 @@ type ClusteredService interface {
 		header *logbuffer.Header,
 	)
 
+	/**
+	 * A scheduled timer has expired.
+	 *
+	 * @param correlationId for the expired timer.
+	 * @param timestamp     at which the timer expired.
+	 */
 	OnTimerEvent(correlationId, timestamp int64)
 
+	/**
+	 * The service should take a snapshot and store its state to the provided archive {@link Publication}.
+	 * <p>
+	 * <b>Note:</b> As this is a potentially long-running operation the implementation should use
+	 * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
+	 * {@link org.agrona.concurrent.IdleStrategy#idle(int)},
+	 * especially when the snapshot {@link ExclusivePublication} returns {@link Publication#BACK_PRESSURED}.
+	 *
+	 * @param publication to which the state should be recorded.
+	 */
 	OnTakeSnapshot(publication *aeron.Publication)
 
+	/**
+	 * Notify that the cluster node has changed role.
+	 *
+	 * @param role that the node has assumed.
+	 */
 	OnRoleChange(role Role)
 
+	/**
+	 * Called when the container is going to terminate.
+	 *
+	 * @param cluster with which the service can interact.
+	 */
 	OnTerminate(cluster Cluster)
 
+	/**
+	 * An election has been successful and a leader has entered a new term.
+	 *
+	 * @param leadershipTermId    identity for the new leadership term.
+	 * @param logPosition         position the log has reached as the result of this message.
+	 * @param timestamp           for the new leadership term.
+	 * @param termBaseLogPosition position at the beginning of the leadership term.
+	 * @param leaderMemberId      who won the election.
+	 * @param logSessionId        session id for the publication of the log.
+	 * @param timeUnit            for the timestamps in the coming leadership term.
+	 * @param appVersion          for the application configured in the consensus module.
+	 */
 	OnNewLeadershipTermEvent(
 		leadershipTermId int64,
 		logPosition int64,

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -726,6 +726,10 @@ func (agent *ClusteredServiceAgent) Time() int64 {
 	return agent.clusterTime
 }
 
+func (agent *ClusteredServiceAgent) TimeUnit() codecs.ClusterTimeUnitEnum {
+	return agent.timeUnit
+}
+
 func (agent *ClusteredServiceAgent) IdleStrategy() idlestrategy.Idler {
 	return agent
 }
@@ -736,6 +740,10 @@ func (agent *ClusteredServiceAgent) ScheduleTimer(correlationId int64, deadline 
 
 func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
 	return agent.proxy.cancelTimer(correlationId)
+}
+
+func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
+	return agent.proxy.Offer(buffer, offset, length)
 }
 
 // END CLUSTER IMPLEMENTATION


### PR DESCRIPTION
Improve documentation of cluster interfaces, and allow `ClusteredServiceAgent` to offer messages to the cluster itself. 

Comments are copied from Java implementation.

Offer capability modeled after Java Implementation:
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/Cluster.java#L304
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L329
- https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java#L117