### PR TITLE
Ensure Close Client Conductor

### DIFF
--- a/aeron/clientconductor.go
+++ b/aeron/clientconductor.go
@@ -308,8 +308,9 @@ func (cc *ClientConductor) run(idleStrategy idlestrategy.Idler) {
 			errStr := fmt.Sprintf("Panic: %v", err)
 			logger.Error(errStr)
 			cc.onError(errors.New(errStr))
-			cc.running.Set(false)
 		}
+
+		cc.running.Set(false)
 		cc.forceCloseResources()
 		cc.conductorRunning.Set(false)
 


### PR DESCRIPTION
Currently, if you
- Create a Media Driver
- Create a Publisher/Subscriber
- Then perform an unceremonious shutdown of the media driver (where `cnc.dat` file is not properly reaped)
- The clientconductor will exit and print "ClientConductor done"
- However, the `cc.running` variable will still reflect as `true`
- Leading services calling `aeron.IsClosed()` to continue seeing `not closed`, and not know that Aeron is actually closed.