### PR TITLE
Offer to cluster

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -603,13 +603,13 @@ func (archive *Archive) StopRecordingByPublication(publication aeron.Publication
 func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*aeron.Publication, error) {
 
 	// This can fail in aeron via log.Fatalf(), not much we can do
-	publication, err := archive.AddPublication(channel, stream)
+	publication, err := archive.AddExclusivePublication(channel, stream)
 	if err != nil {
 		return nil, err
 	}
-	if !publication.IsOriginal() {
-		return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
-	}
+	// if !publication.IsOriginal() {
+	// 	return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
+	// }
 
 	correlationID := nextCorrelationID()
 	logger.Debugf("AddRecordedPublication(), correlationID:%d", correlationID)
@@ -625,7 +625,7 @@ func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*a
 
 	archive.mtx.Lock()
 	defer archive.mtx.Unlock()
-	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, false, sessionChannel); err != nil {
+	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, true, sessionChannel); err != nil {
 		publication.Close()
 		return nil, err
 	}

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -744,10 +744,6 @@ func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
 }
 
 func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
-	if agent.role != Leader {
-		return ClientSessionMockedOffer
-	}
-
 	hdrBuf := agent.sessionMsgHdrBuffer
 	hdrBuf.PutInt64(SBEHeaderLength+8, int64(agent.opts.ServiceId))
 	hdrBuf.PutInt64(SBEHeaderLength+16, agent.clusterTime)

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -749,7 +749,7 @@ func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length 
 	}
 
 	hdrBuf := agent.sessionMsgHdrBuffer
-	hdrBuf.PutInt64(SBEHeaderLength+8, -int64(agent.opts.ServiceId))
+	hdrBuf.PutInt64(SBEHeaderLength+8, int64(agent.opts.ServiceId))
 	hdrBuf.PutInt64(SBEHeaderLength+16, agent.clusterTime)
 	return agent.proxy.Offer2(hdrBuf, 0, hdrBuf.Capacity(), buffer, offset, length)
 }


### PR DESCRIPTION
Offers to the cluster should always happen regardless of whether it is a leader, or follower offering. The Consensus Module has a `republishing_queue` mechanism that is identical to the exact republishing queue methodology written in our rearchitecture doc.

https://docs.google.com/document/d/18ZGByiRvLotow_mNcg-N4NR6HezXtypXkZ4pXOgZNc8/edit#heading=h.k4n9uuf7609z

For Java code references, recognize that Java overloads the `offer` function. There are 4 `offers` defined, two for client offers, and two for cluster offers.
- [Client 1](https://github.com/real-logic/aeron/blob/1.40.0_tutorial_patch/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L591) - [Aeron Go equivalent](https://github.com/lirm/aeron-go/blob/master/cluster/clustered_service_agent.go#L652)
- [Client 2](https://github.com/real-logic/aeron/blob/1.40.0_tutorial_patch/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L617) - Aeron Go doesn't have/need this
- [Cluster 1](https://github.com/real-logic/aeron/blob/1.40.0_tutorial_patch/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L325) - The one we are changing
- [Cluster 2](https://github.com/real-logic/aeron/blob/1.40.0_tutorial_patch/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L333) - Aeron Go doesn't have/need this