### PR TITLE
issue-19: onServiceAction must always send an ack

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -46,7 +46,7 @@ type ClusteredServiceAgent struct {
 	aeronClient              *aeron.Aeron
 	aeronCtx                 *aeron.Context
 	opts                     *Options
-	proxy                    *consensusModuleProxy
+	consensusModuleProxy     *consensusModuleProxy
 	counters                 *counters.Reader
 	serviceAdapter           *serviceAdapter
 	logAdapter               *boundedLogAdapter
@@ -121,20 +121,20 @@ func NewClusteredServiceAgent(
 	}
 
 	agent := &ClusteredServiceAgent{
-		aeronClient:         aeronClient,
-		opts:                options,
-		serviceAdapter:      serviceAdapter,
-		logAdapter:          logAdapter,
-		aeronCtx:            aeronCtx,
-		proxy:               proxy,
-		counters:            countersReader,
-		markFile:            cmf,
-		role:                Follower,
-		service:             service,
-		logPosition:         NullPosition,
-		terminationPosition: NullPosition,
-		sessions:            map[int64]ClientSession{},
-		sessionMsgHdrBuffer: codecs.MakeClusterMessageBuffer(SessionMessageHeaderTemplateId, SessionMessageHdrBlockLength),
+		aeronClient:          aeronClient,
+		opts:                 options,
+		serviceAdapter:       serviceAdapter,
+		logAdapter:           logAdapter,
+		aeronCtx:             aeronCtx,
+		consensusModuleProxy: proxy,
+		counters:             countersReader,
+		markFile:             cmf,
+		role:                 Follower,
+		service:              service,
+		logPosition:          NullPosition,
+		terminationPosition:  NullPosition,
+		sessions:             map[int64]ClientSession{},
+		sessionMsgHdrBuffer:  codecs.MakeClusterMessageBuffer(SessionMessageHeaderTemplateId, SessionMessageHdrBlockLength),
 	}
 	serviceAdapter.agent = agent
 	logAdapter.agent = agent
@@ -193,7 +193,7 @@ func (agent *ClusteredServiceAgent) recoverState() error {
 	agent.sessionMsgHdrBuffer.PutInt64(SBEHeaderLength, leadershipTermId)
 	agent.isServiceActive = true
 
-	if leadershipTermId == -1 {
+	if leadershipTermId == NullValue {
 		agent.service.OnStart(agent, nil)
 	} else {
 		serviceCount, err := agent.counters.GetKeyPartInt32(counterId, 28)
@@ -212,7 +212,7 @@ func (agent *ClusteredServiceAgent) recoverState() error {
 		}
 	}
 
-	agent.proxy.serviceAckRequest(
+	agent.consensusModuleProxy.ack(
 		agent.logPosition,
 		agent.clusterTime,
 		agent.getAndIncrementNextAckId(),
@@ -319,7 +319,7 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 func (agent *ClusteredServiceAgent) terminate() {
 	agent.isServiceActive = false
 	agent.service.OnTerminate(agent)
-	agent.proxy.serviceAckRequest(
+	agent.consensusModuleProxy.ack(
 		agent.logPosition,
 		agent.clusterTime,
 		agent.getAndIncrementNextAckId(),
@@ -398,7 +398,7 @@ func (agent *ClusteredServiceAgent) joinActiveLog(event *activeLogEvent) error {
 	agent.logAdapter.image = img
 	agent.logAdapter.maxLogPosition = event.maxLogPosition
 
-	agent.proxy.serviceAckRequest(
+	agent.consensusModuleProxy.ack(
 		event.logPosition,
 		agent.clusterTime,
 		agent.getAndIncrementNextAckId(),
@@ -550,13 +550,20 @@ func (agent *ClusteredServiceAgent) onServiceAction(
 ) {
 	agent.logPosition = logPos
 	agent.clusterTime = timestamp
+	agent.executeAction(action, logPos, leadershipTermId)
+}
+
+func (agent *ClusteredServiceAgent) executeAction(
+	action codecs.ClusterActionEnum,
+	logPosition,
+	leadershipTermId int64,
+) {
 	if action == codecs.ClusterAction.SNAPSHOT {
-		recordingId, err := agent.takeSnapshot(logPos, leadershipTermId)
+		recordingId, err := agent.takeSnapshot(logPosition, leadershipTermId)
 		if err != nil {
 			logger.Errorf("take snapshot failed: ", err)
-		} else {
-			agent.proxy.serviceAckRequest(logPos, timestamp, agent.getAndIncrementNextAckId(), recordingId, agent.opts.ServiceId)
 		}
+		agent.consensusModuleProxy.ack(logPosition, agent.clusterTime, agent.getAndIncrementNextAckId(), recordingId, agent.opts.ServiceId)
 	}
 }
 
@@ -675,7 +682,7 @@ func (agent *ClusteredServiceAgent) getClientSession(id int64) (ClientSession, b
 func (agent *ClusteredServiceAgent) closeClientSession(id int64) {
 	if _, ok := agent.sessions[id]; ok {
 		// TODO: check if session already closed
-		agent.proxy.closeSessionRequest(id)
+		agent.consensusModuleProxy.closeSessionRequest(id)
 	} else {
 		logger.Errorf("closeClientSession: unknown session id=%d", id)
 	}
@@ -736,18 +743,18 @@ func (agent *ClusteredServiceAgent) IdleStrategy() idlestrategy.Idler {
 }
 
 func (agent *ClusteredServiceAgent) ScheduleTimer(correlationId int64, deadline int64) bool {
-	return agent.proxy.scheduleTimer(correlationId, deadline)
+	return agent.consensusModuleProxy.scheduleTimer(correlationId, deadline)
 }
 
 func (agent *ClusteredServiceAgent) CancelTimer(correlationId int64) bool {
-	return agent.proxy.cancelTimer(correlationId)
+	return agent.consensusModuleProxy.cancelTimer(correlationId)
 }
 
 func (agent *ClusteredServiceAgent) Offer(buffer *atomic.Buffer, offset, length int32) int64 {
 	hdrBuf := agent.sessionMsgHdrBuffer
 	hdrBuf.PutInt64(SBEHeaderLength+8, int64(agent.opts.ServiceId))
 	hdrBuf.PutInt64(SBEHeaderLength+16, agent.clusterTime)
-	return agent.proxy.Offer2(hdrBuf, 0, hdrBuf.Capacity(), buffer, offset, length)
+	return agent.consensusModuleProxy.Offer2(hdrBuf, 0, hdrBuf.Capacity(), buffer, offset, length)
 }
 
 // END CLUSTER IMPLEMENTATION

--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
-	"github.com/lirm/aeron-go/aeron/idlestrategy"
 	"github.com/lirm/aeron-go/cluster/codecs"
 )
 
@@ -17,7 +16,6 @@ const (
 // Proxy class for encapsulating encoding and sending of control protocol messages to a cluster
 type consensusModuleProxy struct {
 	marshaller    *codecs.SbeGoMarshaller // currently shared as we're not reentrant (but could be here)
-	idleStrategy  idlestrategy.Idler
 	rangeChecking bool
 	publication   *aeron.Publication
 	buffer        *atomic.Buffer
@@ -45,7 +43,7 @@ func (proxy *consensusModuleProxy) ack(
 	ackID int64,
 	relevantID int64,
 	serviceID int32,
-) {
+) bool {
 	// Create a packet and send it
 	bytes, err := codecs.ServiceAckRequestPacket(
 		proxy.marshaller,
@@ -59,12 +57,14 @@ func (proxy *consensusModuleProxy) ack(
 	if err != nil {
 		panic(err)
 	}
-	proxy.send(bytes)
+
+	buffer := atomic.MakeBuffer(bytes)
+	return proxy.offer(buffer, 0, buffer.Capacity()) >= 0
 }
 
 func (proxy *consensusModuleProxy) closeSessionRequest(
 	clusterSessionId int64,
-) {
+) bool {
 	// Create a packet and send it
 	bytes, err := codecs.CloseSessionRequestPacket(
 		proxy.marshaller,
@@ -74,7 +74,8 @@ func (proxy *consensusModuleProxy) closeSessionRequest(
 	if err != nil {
 		panic(err)
 	}
-	proxy.send(bytes)
+	buffer := atomic.MakeBuffer(bytes)
+	return proxy.offer(buffer, 0, buffer.Capacity()) >= 0
 }
 
 func (proxy *consensusModuleProxy) scheduleTimer(correlationId int64, deadline int64) bool {
@@ -99,14 +100,6 @@ func (proxy *consensusModuleProxy) initBuffer(templateId uint16, blockLength uin
 	return buf
 }
 
-// send to our request publication
-func (proxy *consensusModuleProxy) send(payload []byte) {
-	buffer := atomic.MakeBuffer(payload)
-	for proxy.offer(buffer, 0, buffer.Capacity()) < 0 {
-		proxy.idleStrategy.Idle(0)
-	}
-}
-
 func (proxy *consensusModuleProxy) offer(buffer *atomic.Buffer, offset, length int32) int64 {
 	result := proxy.publication.Offer(buffer, offset, length, nil)
 	checkResult(result)
@@ -123,14 +116,9 @@ func (proxy *consensusModuleProxy) Offer2(
 	bufferOne *atomic.Buffer, offsetOne int32, lengthOne int32,
 	bufferTwo *atomic.Buffer, offsetTwo int32, lengthTwo int32,
 ) int64 {
-	var result int64
-	for i := 0; i < 3; i++ {
-		result = proxy.publication.Offer2(bufferOne, offsetOne, lengthOne, bufferTwo, offsetTwo, lengthTwo, nil)
-		if result >= 0 {
-			break
-		} else if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
-			panic(fmt.Sprintf("offer failed, result=%d", result))
-		}
+	result := proxy.publication.Offer2(bufferOne, offsetOne, lengthOne, bufferTwo, offsetTwo, lengthTwo, nil)
+	if result < 0 {
+		checkResult(result)
 	}
 	return result
 }

--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -39,7 +39,7 @@ func newConsensusModuleProxy(
 // publication. Responses will be processed on the control
 
 // ConnectRequest packet and send
-func (proxy *consensusModuleProxy) serviceAckRequest(
+func (proxy *consensusModuleProxy) ack(
 	logPosition int64,
 	timestamp int64,
 	ackID int64,
@@ -108,16 +108,15 @@ func (proxy *consensusModuleProxy) send(payload []byte) {
 }
 
 func (proxy *consensusModuleProxy) offer(buffer *atomic.Buffer, offset, length int32) int64 {
-	var result int64
-	for i := 0; i < 3; i++ {
-		result = proxy.publication.Offer(buffer, offset, length, nil)
-		if result >= 0 {
-			break
-		} else if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
-			panic(fmt.Sprintf("offer failed, result=%d", result))
-		}
-	}
+	result := proxy.publication.Offer(buffer, offset, length, nil)
+	checkResult(result)
 	return result
+}
+
+func checkResult(result int64) {
+	if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
+		panic(fmt.Sprintf("unexpected publication state, result=%d", result))
+	}
 }
 
 func (proxy *consensusModuleProxy) Offer2(

--- a/cluster/constants.go
+++ b/cluster/constants.go
@@ -9,8 +9,8 @@ type Role int32
 
 const (
 	Follower  Role = 0
-	Candidate      = 1
-	Leader         = 2
+	Candidate Role = 1
+	Leader    Role = 2
 )
 
 const (
@@ -34,6 +34,7 @@ const (
 	serviceTerminationPosTemplateId = 42
 	snapshotMarkerTemplateId        = 100
 	clientSessionTemplateId         = 102
+	RequestServiceAckId             = 108
 )
 
 const SessionMessageHdrBlockLength = 24

--- a/cluster/service_adapter.go
+++ b/cluster/service_adapter.go
@@ -65,7 +65,13 @@ func (adapter *serviceAdapter) onFragment(
 	case serviceTerminationPosTemplateId:
 		logPos := buffer.GetInt64(offset)
 		adapter.agent.onServiceTerminationPosition(logPos)
+
+	case RequestServiceAckId:
+		logPos := buffer.GetInt64(offset)
+		adapter.agent.OnRequestServiceAck(logPos)
+
 	default:
 		logger.Debugf("serviceAdapter: unexpected templateId=%d at pos=%d", templateId, header.Position())
 	}
+
 }


### PR DESCRIPTION
Fix issue 19 of Aeron-Go audit by adaptive

			
## Description
- clustered_service_agent.onServiceAction does not send ack in case of an error.
- rename some fields and method to be in line with Java's implementation
## Severity
Critical
## Implications 
An ack for a service action must be reliably sent (retried indefinitely) to the ConsensusModule always otherwise it will block forever waiting for it. In case of an error a NullValue should be sent instead of a recordingId.
## Code
- Go https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L545-L561
- Java https://github.com/real-logic/aeron/blob/154532e71d57fb90b51111c3caae02da4d10f47e/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L1006-L1036