### PR TITLE
issue-14 / issue-22: move retry logic out of consensus_module_proxy 

### DIFF
--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
-	"github.com/lirm/aeron-go/aeron/idlestrategy"
 	"github.com/lirm/aeron-go/cluster/codecs"
 )
 
@@ -17,7 +16,6 @@ const (
 // Proxy class for encapsulating encoding and sending of control protocol messages to a cluster
 type consensusModuleProxy struct {
 	marshaller    *codecs.SbeGoMarshaller // currently shared as we're not reentrant (but could be here)
-	idleStrategy  idlestrategy.Idler
 	rangeChecking bool
 	publication   *aeron.Publication
 	buffer        *atomic.Buffer
@@ -45,7 +43,7 @@ func (proxy *consensusModuleProxy) ack(
 	ackID int64,
 	relevantID int64,
 	serviceID int32,
-) {
+) bool {
 	// Create a packet and send it
 	bytes, err := codecs.ServiceAckRequestPacket(
 		proxy.marshaller,
@@ -59,12 +57,14 @@ func (proxy *consensusModuleProxy) ack(
 	if err != nil {
 		panic(err)
 	}
-	proxy.send(bytes)
+
+	buffer := atomic.MakeBuffer(bytes)
+	return proxy.offer(buffer, 0, buffer.Capacity()) >= 0
 }
 
 func (proxy *consensusModuleProxy) closeSessionRequest(
 	clusterSessionId int64,
-) {
+) bool {
 	// Create a packet and send it
 	bytes, err := codecs.CloseSessionRequestPacket(
 		proxy.marshaller,
@@ -74,7 +74,8 @@ func (proxy *consensusModuleProxy) closeSessionRequest(
 	if err != nil {
 		panic(err)
 	}
-	proxy.send(bytes)
+	buffer := atomic.MakeBuffer(bytes)
+	return proxy.offer(buffer, 0, buffer.Capacity()) >= 0
 }
 
 func (proxy *consensusModuleProxy) scheduleTimer(correlationId int64, deadline int64) bool {
@@ -99,14 +100,6 @@ func (proxy *consensusModuleProxy) initBuffer(templateId uint16, blockLength uin
 	return buf
 }
 
-// send to our request publication
-func (proxy *consensusModuleProxy) send(payload []byte) {
-	buffer := atomic.MakeBuffer(payload)
-	for proxy.offer(buffer, 0, buffer.Capacity()) < 0 {
-		proxy.idleStrategy.Idle(0)
-	}
-}
-
 func (proxy *consensusModuleProxy) offer(buffer *atomic.Buffer, offset, length int32) int64 {
 	result := proxy.publication.Offer(buffer, offset, length, nil)
 	checkResult(result)
@@ -123,14 +116,9 @@ func (proxy *consensusModuleProxy) Offer2(
 	bufferOne *atomic.Buffer, offsetOne int32, lengthOne int32,
 	bufferTwo *atomic.Buffer, offsetTwo int32, lengthTwo int32,
 ) int64 {
-	var result int64
-	for i := 0; i < 3; i++ {
-		result = proxy.publication.Offer2(bufferOne, offsetOne, lengthOne, bufferTwo, offsetTwo, lengthTwo, nil)
-		if result >= 0 {
-			break
-		} else if result == aeron.NotConnected || result == aeron.PublicationClosed || result == aeron.MaxPositionExceeded {
-			panic(fmt.Sprintf("offer failed, result=%d", result))
-		}
+	result := proxy.publication.Offer2(bufferOne, offsetOne, lengthOne, bufferTwo, offsetTwo, lengthTwo, nil)
+	if result < 0 {
+		checkResult(result)
 	}
 	return result
 }

--- a/cluster/constants.go
+++ b/cluster/constants.go
@@ -9,8 +9,8 @@ type Role int32
 
 const (
 	Follower  Role = 0
-	Candidate      = 1
-	Leader         = 2
+	Candidate Role = 1
+	Leader    Role = 2
 )
 
 const (
@@ -34,6 +34,7 @@ const (
 	serviceTerminationPosTemplateId = 42
 	snapshotMarkerTemplateId        = 100
 	clientSessionTemplateId         = 102
+	RequestServiceAckId             = 108
 )
 
 const SessionMessageHdrBlockLength = 24

--- a/cluster/service_adapter.go
+++ b/cluster/service_adapter.go
@@ -65,7 +65,13 @@ func (adapter *serviceAdapter) onFragment(
 	case serviceTerminationPosTemplateId:
 		logPos := buffer.GetInt64(offset)
 		adapter.agent.onServiceTerminationPosition(logPos)
+
+	case RequestServiceAckId:
+		logPos := buffer.GetInt64(offset)
+		adapter.agent.OnRequestServiceAck(logPos)
+
 	default:
 		logger.Debugf("serviceAdapter: unexpected templateId=%d at pos=%d", templateId, header.Position())
 	}
+
 }


### PR DESCRIPTION
Fix issue 14 and 22 of Aeron-Go audit by adaptive

			
## Description
- `consensus_module_proxy` should not retry operations. The retry/idle logic is moved to `clustered_service_agent`
- Add a missing control flow for `requestedAckPosition`. Consensus module with from time to time poll the cluster to retrieve the latest ack-ed position. This is likely added in later version of aeron java and doesn't appear in aeron go
## Severity
Medium/High
## Implications 
Retry logic depends on the context an operation is executed in and hence cannot be done internally. Wrong retry might lead to an infinite loop or actions not being executed. Also internal retry means that the idle/slow tick logic will not be executed leading to other issues associated with that.
## Code
- Go https://github.com/lirm/aeron-go/blob/master/cluster/consensus_module_proxy.go
- Java https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java