### PR TITLE
issue-21: fix issues with recoverState

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -173,7 +173,11 @@ func (agent *ClusteredServiceAgent) OnStart() error {
 	if err := agent.awaitCommitPositionCounter(); err != nil {
 		return err
 	}
-	return agent.recoverState()
+	if err := agent.recoverState(); err != nil {
+		return err
+	}
+	agent.isServiceActive = true
+	return nil
 }
 
 func (agent *ClusteredServiceAgent) awaitCommitPositionCounter() error {
@@ -192,29 +196,21 @@ func (agent *ClusteredServiceAgent) awaitCommitPositionCounter() error {
 }
 
 func (agent *ClusteredServiceAgent) recoverState() error {
-	counterId, leadershipTermId := agent.awaitRecoveryCounter()
+	recoveryCounterId, leadershipTermId := agent.awaitRecoveryCounter()
 	logger.Debugf("found recovery counter - id=%d leadershipTermId=%d logPos=%d clusterTime=%d",
-		counterId, leadershipTermId, agent.logPosition, agent.clusterTime)
+		recoveryCounterId, leadershipTermId, agent.logPosition, agent.clusterTime)
 	agent.sessionMsgHdrBuffer.PutInt64(SBEHeaderLength, leadershipTermId)
-	agent.isServiceActive = true
 
-	if leadershipTermId == NullValue {
-		agent.service.OnStart(agent, nil)
-	} else {
-		serviceCount, err := agent.counters.GetKeyPartInt32(counterId, 28)
-		if err != nil {
-			return err
-		}
-		if serviceCount < 1 {
-			return fmt.Errorf("invalid service count: %d", serviceCount)
-		}
-		snapshotRecId, err := agent.counters.GetKeyPartInt64(counterId, 32+(agent.opts.ServiceId*util.SizeOfInt64))
+	if leadershipTermId != NullValue {
+		snapshotRecId, err := getSnapshotRecordingID(agent.counters, recoveryCounterId, agent.opts.ServiceId)
 		if err != nil {
 			return err
 		}
 		if err := agent.loadSnapshot(snapshotRecId); err != nil {
 			return err
 		}
+	} else {
+		agent.service.OnStart(agent, nil)
 	}
 
 	ackId := agent.getAndIncrementNextAckId()
@@ -228,6 +224,17 @@ func (agent *ClusteredServiceAgent) recoverState() error {
 		agent.Idle(0)
 	}
 	return nil
+}
+
+func getSnapshotRecordingID(counters *counters.Reader, recoveryCounterId, serviceId int32) (int64, error) {
+	serviceCount, err := counters.GetKeyPartInt32(recoveryCounterId, 28)
+	if err != nil {
+		return 0, err
+	}
+	if serviceId < 0 || serviceId >= serviceCount {
+		return 0, fmt.Errorf("invalid service id %d for count of: %d", serviceId, serviceCount)
+	}
+	return counters.GetKeyPartInt64(recoveryCounterId, 32+(serviceId*util.SizeOfInt64))
 }
 
 func (agent *ClusteredServiceAgent) awaitRecoveryCounter() (int32, int64) {
@@ -267,8 +274,7 @@ func (agent *ClusteredServiceAgent) loadSnapshot(recordingId int64) error {
 		return err
 	}
 
-	logger.Debugf("replaying snapshot - recId=%d sessionId=%d streamId=%d",
-		recordingId, replaySessionId, streamId)
+	logger.Debugf("replaying snapshot - recId=%d sessionId=%d streamId=%d", recordingId, replaySessionId, streamId)
 	subscription, err := arch.AddSubscription(subChannel, streamId)
 	if err != nil {
 		return err
@@ -276,18 +282,24 @@ func (agent *ClusteredServiceAgent) loadSnapshot(recordingId int64) error {
 	defer closeSubscription(subscription)
 
 	img := agent.awaitImage(int32(replaySessionId), subscription)
-	loader := newSnapshotLoader(agent, img)
-	for !loader.isDone {
-		agent.opts.IdleStrategy.Idle(loader.poll())
-	}
-	if util.SemanticVersionMajor(uint32(agent.opts.AppVersion)) != util.SemanticVersionMajor(uint32(loader.appVersion)) {
-		panic(fmt.Errorf("incompatible app version: %v snapshot=%v",
-			util.SemanticVersionToString(uint32(agent.opts.AppVersion)),
-			util.SemanticVersionToString(uint32(loader.appVersion))))
-	}
-	agent.timeUnit = loader.timeUnit
+	agent.loadState(img, arch)
 	agent.service.OnStart(agent, img)
 	return nil
+}
+
+func (agent *ClusteredServiceAgent) loadState(image aeron.Image, archive *archive.Archive) {
+	snapshotLoader := newSnapshotLoader(agent, image)
+	for !snapshotLoader.isDone {
+		fragments := snapshotLoader.poll()
+		agent.opts.IdleStrategy.Idle(fragments)
+	}
+
+	if util.SemanticVersionMajor(uint32(agent.opts.AppVersion)) != util.SemanticVersionMajor(uint32(snapshotLoader.appVersion)) {
+		panic(fmt.Errorf("incompatible app version: %v snapshot=%v",
+			util.SemanticVersionToString(uint32(agent.opts.AppVersion)),
+			util.SemanticVersionToString(uint32(snapshotLoader.appVersion))))
+	}
+	agent.timeUnit = snapshotLoader.timeUnit
 }
 
 func (agent *ClusteredServiceAgent) addSessionFromSnapshot(session *containerClientSession) {

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -304,6 +304,10 @@ func (agent *ClusteredServiceAgent) loadState(image aeron.Image, archive *archiv
 		agent.opts.IdleStrategy.Idle(fragments)
 	}
 
+	if snapshotLoader.err != nil {
+		return snapshotLoader.err
+	}
+
 	if util.SemanticVersionMajor(uint32(agent.opts.AppVersion)) != util.SemanticVersionMajor(uint32(snapshotLoader.appVersion)) {
 		panic(fmt.Errorf("incompatible app version: %v snapshot=%v",
 			util.SemanticVersionToString(uint32(agent.opts.AppVersion)),

--- a/cluster/snapshot_loader.go
+++ b/cluster/snapshot_loader.go
@@ -75,10 +75,10 @@ func (loader *snapshotLoader) onFragment(
 			loader.err = err
 			loader.isDone = true
 		} else if marker.TypeId != snapshotTypeId {
-			panic(fmt.Sprintf("unexpected snapshot type: %d", marker.TypeId))
+			loader.err = fmt.Errorf("unexpected snapshot type: %d", marker.TypeId)
+			loader.isDone = true
 		}
 		switch marker.Mark {
-
 		case codecs.SnapshotMark.BEGIN:
 			if loader.inSnapshot {
 				loader.err = fmt.Errorf("already in snapshot, pos=%d", header.Position())

--- a/cluster/snapshot_loader.go
+++ b/cluster/snapshot_loader.go
@@ -75,8 +75,11 @@ func (loader *snapshotLoader) onFragment(
 			loader.err = err
 			loader.isDone = true
 		} else if marker.TypeId != snapshotTypeId {
-			loader.err = fmt.Errorf("unexpected snapshot type: %d", marker.TypeId)
-		} else if marker.Mark == codecs.SnapshotMark.BEGIN {
+			panic(fmt.Sprintf("unexpected snapshot type: %d", marker.TypeId))
+		}
+		switch marker.Mark {
+
+		case codecs.SnapshotMark.BEGIN:
 			if loader.inSnapshot {
 				loader.err = fmt.Errorf("already in snapshot, pos=%d", header.Position())
 				loader.isDone = true
@@ -85,7 +88,7 @@ func (loader *snapshotLoader) onFragment(
 				loader.appVersion = marker.AppVersion
 				loader.timeUnit = marker.TimeUnit
 			}
-		} else if marker.Mark == codecs.SnapshotMark.END {
+		case codecs.SnapshotMark.END:
 			if !loader.inSnapshot {
 				loader.err = fmt.Errorf("missing beging snapshot, pos=%d", header.Position())
 				loader.isDone = true
@@ -93,10 +96,12 @@ func (loader *snapshotLoader) onFragment(
 				loader.inSnapshot = false
 				loader.isDone = true
 			}
-		} else {
+
+		case codecs.SnapshotMark.SECTION, codecs.SnapshotMark.NullValue:
 			loader.err = fmt.Errorf("unexpected snapshot mark, pos=%d inSnapshot=%v mark=%v", header.Position(), loader.inSnapshot, marker.Mark)
 			loader.isDone = true
 		}
+
 	case clientSessionTemplateId:
 		s := codecs.ClientSession{}
 		if err := s.Decode(loader.marshaller, buf, version, blockLength, true); err != nil {


### PR DESCRIPTION
## Description
 clustered_service_agent.recoverState issues:
- [x] marks service as active before restoring any state.
- [x] serviceId/serviceCount validation is wrong.
- [ ] does not invoke clustered_service_agent.idle(workCount) while restoring state and/or awaiting resources. The same applies to snapshot_loader.
- [x] snapshot_loader does not exist on wrong snapshotTypeId. <- I assume it's a typo on exit
- [ ] snapshot_loader eagerly connects egress Publications while state is being restored. Egress should be only connected from onSessionOpen or joinActiveLog.
- [x] sending an ack should be retried indefinitely. See Issue #9 .

## Implications
Might fail to restore state and thus fail node startup.

## Code
- Go: https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L189-L223, https://github.com/lirm/aeron-go/blob/master/cluster/snapshot_loader.go
- Java: https://github.com/real-logic/aeron/blob/fe0b15946ec89a850382b8ebbb0b2ac48b439cc4/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L738-L768 , https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/service/RecoveryState.java#L232-L253