### PR TITLE
issue-20: Fix broken cluster_service_agent.takeSnapshot

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -652,7 +652,7 @@ func (agent *ClusteredServiceAgent) takeSnapshot(logPos int64, leadershipTermId 
 	return recordingId, nil
 }
 
-func (agent *ClusteredServiceAgent) awaitRecordingComplete(sessionId int32, arch *archive.Archive) (int64, error) {
+func (agent *ClusteredServiceAgent) awaitRecordingId(sessionId int32, arch *archive.Archive) (int64, error) {
 	for {
 		recId := int64(NullValue)
 		counterId := agent.counters.FindCounter(recordingPosCounterTypeId, func(keyBuffer *atomic.Buffer) bool {
@@ -672,7 +672,7 @@ func (agent *ClusteredServiceAgent) awaitRecordingComplete(sessionId int32, arch
 	}
 }
 
-func (agent *ClusteredServiceAgent) awaitRecordingId(sessionId int32) (int64, error) {
+func (agent *ClusteredServiceAgent) awaitRecordingIdWithTimeout(sessionId int32) (int64, error) {
 	start := time.Now()
 	for time.Since(start) < agent.opts.Timeout {
 		recId := int64(NullValue)

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -682,7 +682,7 @@ func (agent *ClusteredServiceAgent) awaitRecordingComplete(recordingId int64, po
 			return err
 		}
 
-		if archive.IsRecordingActive(agent.counters, counterId, recordingId) {
+		if !archive.IsRecordingActive(agent.counters, counterId, recordingId) {
 			return fmt.Errorf("cluster exception - recording stopped unexpectedly: %d", recordingId)
 		}
 	}

--- a/cluster/snapshot_taker.go
+++ b/cluster/snapshot_taker.go
@@ -100,7 +100,7 @@ func (st *snapshotTaker) offer(bytes []byte) int64 {
 			st.options.IdleStrategy.Idle(0)
 		// Fail on these
 		case aeron.NotConnected, aeron.PublicationClosed, aeron.MaxPositionExceeded:
-			logger.Warningf("unexpected publication state: %d", ret)
+			logger.Warningf("cluster exception - unexpected publication state: %d", ret)
 			return ret
 		}
 	}

--- a/cluster/snapshot_taker.go
+++ b/cluster/snapshot_taker.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
@@ -89,19 +88,20 @@ func (st *snapshotTaker) snapshotSession(session ClientSession) error {
 func (st *snapshotTaker) offer(bytes []byte) int64 {
 	buffer := atomic.MakeBuffer(bytes)
 	length := int32(len(bytes))
-	start := time.Now()
 	var ret int64
-	for time.Since(start) < st.options.Timeout {
+	for {
 		ret = st.publication.Offer(buffer, 0, length, nil)
+		if ret > 0 {
+			return ret
+		}
 		switch ret {
 		// Retry on these
-		case aeron.NotConnected, aeron.BackPressured, aeron.AdminAction:
+		case aeron.BackPressured, aeron.AdminAction:
 			st.options.IdleStrategy.Idle(0)
-		// Fail or succeed on other values
-		default:
+		// Fail on these
+		case aeron.NotConnected, aeron.PublicationClosed, aeron.MaxPositionExceeded:
+			logger.Warningf("unexpected publication state: %d", ret)
 			return ret
 		}
 	}
-	// Give up, returning the last failure
-	return ret
 }


### PR DESCRIPTION
Fix issue 20 of Aeron-Go audit by adaptive

## Description
`clustered_service_agent.takeSnapshot` is broken:
- [x] clustered_service_agent.awaitRecordingId can timeout instead of retrying indefinitely. It also lacks a check for Archive errors.
- [x] snapshot_taker.offer can timeout instead of retrying indefinitely. It also retry on NOT_CONNECTED state which should be treated as error in this case.
- [x] does not await recording completion

## Severity
Critical

## Implications 
Not taking a snapshot or even worse taking a partial snapshot will lead to state divergence and inability to recover from the said snapshot.

## Code
- Go:  https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L586-L621 , https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L623-L640 , https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/snapshot_taker.go#L89-L106
- Java: https://github.com/real-logic/aeron/blob/154532e71d57fb90b51111c3caae02da4d10f47e/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L939-L968 https://github.com/real-logic/aeron/blob/154532e71d57fb90b51111c3caae02da4d10f47e/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L1043-L1056 https://github.com/real-logic/aeron/blob/154532e71d57fb90b51111c3caae02da4d10f47e/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L970-L988