### PR TITLE
issue-12 : Disconnect egress publication when going into election

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -403,6 +403,10 @@ type activeLogEvent struct {
 }
 
 func (agent *ClusteredServiceAgent) joinActiveLog(event *activeLogEvent) error {
+	if event.role != Leader {
+		agent.disconnectEgress()
+	}
+
 	logSub, err := agent.aeronClient.AddSubscription(event.logChannel, event.logStreamId)
 	if err != nil {
 		return err
@@ -442,7 +446,14 @@ func (agent *ClusteredServiceAgent) closeLog() {
 	if err := agent.logAdapter.Close(); err != nil {
 		logger.Errorf("error closing log image: %v", err)
 	}
+	agent.disconnectEgress()
 	agent.setRole(Follower)
+}
+
+func (agent *ClusteredServiceAgent) disconnectEgress() {
+	for _, session := range agent.sessions {
+		session.Close()
+	}
 }
 
 func (agent *ClusteredServiceAgent) setRole(newRole Role) {

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -452,7 +452,7 @@ func (agent *ClusteredServiceAgent) closeLog() {
 
 func (agent *ClusteredServiceAgent) disconnectEgress() {
 	for _, session := range agent.sessions {
-		session.Close()
+		session.Disconnect()
 	}
 }
 


### PR DESCRIPTION
depending on #13 to be merged first for .Disconnect() method

## Description 
Not disconnecting egress publications when going into an election.
## Severity
High
## Implications 
Without closing egress publications there is no way to notify Cluster clients that the leader is going away and thus to prevent messages to still be offered to an invalid ingress publication.

# Code
- Go: https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L416-L425 , https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L386
- Java: https://github.com/real-logic/aeron/blob/8dccf9dca51cbad3aa4f7a3abf17dbedc5a90199/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L783-L789 https://github.com/real-logic/aeron/blob/8dccf9dca51cbad3aa4f7a3abf17dbedc5a90199/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L801-L804