### PR TITLE
issue-18 : disconnect egress pub on clustered_service_agent.onSessionClose

### DIFF
--- a/cluster/client_session.go
+++ b/cluster/client_session.go
@@ -34,6 +34,7 @@ type ClientSession interface {
 	// IsClosing() bool
 	Offer(*atomic.Buffer, int32, int32, term.ReservedValueSupplier) int64
 	// TryClaim(...)
+	Disconnect()
 }
 
 type containerClientSession struct {
@@ -86,6 +87,13 @@ func (s *containerClientSession) Close() {
 	if _, ok := s.agent.getClientSession(s.id); ok {
 		s.agent.closeClientSession(s.id)
 	}
+}
+
+func (s *containerClientSession) Disconnect() {
+	if err := s.response.Close(); err != nil {
+		logger.Warningf("Failed to disconnect publication: %v", err)
+	}
+	s.response = nil
 }
 
 func (s *containerClientSession) Offer(

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -510,6 +510,7 @@ func (agent *ClusteredServiceAgent) onSessionClose(
 
 	if session, ok := agent.sessions[clusterSessionId]; ok {
 		delete(agent.sessions, clusterSessionId)
+		session.Disconnect()
 		agent.service.OnSessionClose(session, timestamp, closeReason)
 	} else {
 		logger.Errorf("onSessionClose: unknown session - id=%d leaderTermId=%d logPos=%d reason=%v",


### PR DESCRIPTION
## Description
clustered_service_agent.onSessionClose does not disconnect an egress publication.

## Severity
Medium

## Implication
Leaving egress Publication not closed means that it will hang around longer than necessary and that it will be possible to use it by mistake (e.g. calling client_session.Offer from clustered_service.OnSessionClose callback).

## Code
- Go  - https://github.com/lirm/aeron-go/blob/f6902ab3164a1264c42b0627d2c4811f5d025e94/cluster/clustered_service_agent.go#L480-L497
- Java - https://github.com/real-logic/aeron/blob/8dccf9dca51cbad3aa4f7a3abf17dbedc5a90199/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L510-L541