### PR TITLE
Clean up resources on exit and  on SIGINT/SIGTERM for consistency with java impl

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -606,13 +606,13 @@ func (archive *Archive) StopRecordingByPublication(publication aeron.Publication
 func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*aeron.Publication, error) {
 
 	// This can fail in aeron via log.Fatalf(), not much we can do
-	publication, err := archive.AddExclusivePublication(channel, stream)
+	publication, err := archive.AddPublication(channel, stream)
 	if err != nil {
 		return nil, err
 	}
-	// if !publication.IsOriginal() {
-	// 	return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
-	// }
+	if !publication.IsOriginal() {
+		return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
+	}
 
 	correlationID := nextCorrelationID()
 	logger.Debugf("AddRecordedPublication(), correlationID:%d", correlationID)
@@ -628,7 +628,7 @@ func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*a
 
 	archive.mtx.Lock()
 	defer archive.mtx.Unlock()
-	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, true, sessionChannel); err != nil {
+	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, false, sessionChannel); err != nil {
 		publication.Close()
 		return nil, err
 	}

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -606,13 +606,13 @@ func (archive *Archive) StopRecordingByPublication(publication aeron.Publication
 func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*aeron.Publication, error) {
 
 	// This can fail in aeron via log.Fatalf(), not much we can do
-	publication, err := archive.AddPublication(channel, stream)
+	publication, err := archive.AddExclusivePublication(channel, stream)
 	if err != nil {
 		return nil, err
 	}
-	if !publication.IsOriginal() {
-		return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
-	}
+	// if !publication.IsOriginal() {
+	// 	return nil, fmt.Errorf("publication already added for channel=%s stream=%d", channel, stream)
+	// }
 
 	correlationID := nextCorrelationID()
 	logger.Debugf("AddRecordedPublication(), correlationID:%d", correlationID)
@@ -628,7 +628,7 @@ func (archive *Archive) AddRecordedPublication(channel string, stream int32) (*a
 
 	archive.mtx.Lock()
 	defer archive.mtx.Unlock()
-	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, false, sessionChannel); err != nil {
+	if err := archive.Proxy.StartRecordingRequest(correlationID, stream, true, true, sessionChannel); err != nil {
 		publication.Close()
 		return nil, err
 	}

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -408,7 +408,9 @@ func (agent *ClusteredServiceAgent) CloseResource() {
 		agent.disconnectEgress()
 	}
 	agent.markFile.UpdateActivityTimestamp(NullValue)
-	agent.markFile.SignalReady()
+	if err := agent.markFile.file.Close(); err != nil {
+		logger.Error("failed to close markFile: %v", err)
+	}
 }
 
 func (agent *ClusteredServiceAgent) terminate() {

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -394,7 +394,11 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 	}
 }
 
-func (agent *ClusteredServiceAgent) CloseResource() {
+func (agent *ClusteredServiceAgent) OnClose() {
+	if agent.isServiceActive {
+		agent.isServiceActive = false
+		agent.service.OnTerminate(agent)
+	}
 	if err := agent.logAdapter.Close(); err != nil {
 		logger.Errorf("error closing log image: %v", err)
 	}
@@ -402,7 +406,7 @@ func (agent *ClusteredServiceAgent) CloseResource() {
 		if err := agent.serviceAdapter.subscription.Close(); err != nil {
 			logger.Error("failed to close service adapter subscription: %v", err)
 		}
-		if err := agent.consensusModuleProxy.publication.Close(); err != nil  {
+		if err := agent.consensusModuleProxy.publication.Close(); err != nil {
 			logger.Error("failed to close consensusModuleProxy.publication: %v", err)
 		}
 		agent.disconnectEgress()

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -396,6 +396,20 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 	}
 }
 
+func (agent *ClusteredServiceAgent) CloseResources() {
+	agent.closeLog()
+	if !agent.aeronClient.IsClosed() {
+		if err := agent.serviceAdapter.subscription.Close(); err != nil {
+			logger.Error("failed to close service adapter subscription: %v", err)
+		}
+		if err := agent.consensusModuleProxy.publication.Close(); err != nil  {
+			logger.Error("failed to close consensusModuleProxy.publication: %v", err)
+		}
+	}
+	agent.markFile.UpdateActivityTimestamp(NullValue)
+	agent.markFile.SignalReady()
+}
+
 func (agent *ClusteredServiceAgent) terminate() {
 	agent.isServiceActive = false
 	agent.activeLifecycleCallback = LIFECYCLE_CALLBACK_ON_TERMINATE

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -177,21 +176,12 @@ func (agent *ClusteredServiceAgent) StartAndRunWithGracefulShutdown() error {
 	agent.signalChan = make(chan os.Signal, 1)
 	signal.Notify(agent.signalChan, syscall.SIGINT, syscall.SIGTERM)
 	defer agent.OnClose()
-	// defer close(agent.signalChan)
-	// defer signal.Stop(agent.signalChan)
+
 	go func() {
-		for {
-			select {
-			case <-agent.signalChan:
-				// signal.Stop(agent.signalChan)
-				// close(agent.signalChan)
-				agent.OnClose()
-				return
-			default:
-				runtime.Gosched()
-			}
-		}
+		<-agent.signalChan
+		agent.OnClose()
 	}()
+
 	return agent.StartAndRun()
 }
 

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -394,6 +394,9 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 	}
 }
 
+// We need to call this on end of each StartAndRun() like how java does it with finally
+// Either we defer agent.OnClose() or trap signal and execute it
+// https://github.com/real-logic/aeron/blob/master/aeron-samples/src/main/java/io/aeron/samples/stress/StressMdcClient.java#L292
 func (agent *ClusteredServiceAgent) OnClose() {
 	if agent.isServiceActive {
 		agent.isServiceActive = false

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -397,7 +397,9 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 }
 
 func (agent *ClusteredServiceAgent) CloseResource() {
-	agent.closeLog()
+	if err := agent.logAdapter.Close(); err != nil {
+		logger.Errorf("error closing log image: %v", err)
+	}
 	if !agent.aeronClient.IsClosed() {
 		if err := agent.serviceAdapter.subscription.Close(); err != nil {
 			logger.Error("failed to close service adapter subscription: %v", err)
@@ -405,6 +407,7 @@ func (agent *ClusteredServiceAgent) CloseResource() {
 		if err := agent.consensusModuleProxy.publication.Close(); err != nil  {
 			logger.Error("failed to close consensusModuleProxy.publication: %v", err)
 		}
+		agent.disconnectEgress()
 	}
 	agent.markFile.UpdateActivityTimestamp(NullValue)
 	agent.markFile.SignalReady()

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -396,7 +396,7 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 	}
 }
 
-func (agent *ClusteredServiceAgent) CloseResources() {
+func (agent *ClusteredServiceAgent) CloseResource() {
 	agent.closeLog()
 	if !agent.aeronClient.IsClosed() {
 		if err := agent.serviceAdapter.subscription.Close(); err != nil {


### PR DESCRIPTION
This PR fixes the root cause of the inability to restart node cleanly. 
TLDR: it is due to `aeron-go` not closing any resources (MediaDriver context, markfile, publications...). We have put aeron-go back on par with `aeron-java` in term of stability in this area.

- Before: Whenever we kill a node (service + consensus), if we restart it in less than **10 seconds**, the election is never concluded. Some nodes will stuck in state < 17 (terminal state for election)
- After: Same setup, restart after **1 second**. I tried 20 times and it always get to terminal state
Thus I think we can safely say that we have sufficiently solved the restart issue.

Next step:
- On all the code path that the service can terminate, we have to close resources. Right now, the only part left unhandled is panics. This will need individual service to handle resource closure in such cases.
Without this, we are still able to recover. Just need to restart all MediaDriver/Archive/Consensus/Services.

Original slack thread https://app.slack.com/client/T040R9VNPPS/C0504ARTY58
