### PR TITLE
[Issue-20-a] PE-35 Cluster Service Agent snapshot fix

### DIFF
--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -245,7 +245,7 @@ func (agent *ClusteredServiceAgent) recoverState() error {
 	agent.activeLifecycleCallback = LIFECYCLE_CALLBACK_NONE
 
 	ackId := agent.getAndIncrementNextAckId()
-	logger.Infof("ack :: recoveryState :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: recoveryState :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	for !agent.consensusModuleProxy.ack(
 		agent.logPosition,
 		agent.clusterTime,
@@ -255,7 +255,7 @@ func (agent *ClusteredServiceAgent) recoverState() error {
 	) {
 		agent.Idle(0)
 	}
-	logger.Infof("ack :: recoveryState :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: recoveryState :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	return nil
 }
 
@@ -403,11 +403,11 @@ func (agent *ClusteredServiceAgent) pollServiceAdapter() {
 			logger.Errorf("invalid ack request: logPos=%d > requestedAckPos=%d", agent.logPosition, agent.requestedAckPosition)
 		}
 		ackId := agent.getAndIncrementNextAckId()
-		logger.Infof("ack :: pollServiceAdapter :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+		logger.Debugf("ack :: pollServiceAdapter :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 		for !agent.consensusModuleProxy.ack(agent.logPosition, agent.clusterTime, ackId, NullValue, agent.opts.ServiceId) {
 			agent.Idle(0)
 		}
-		logger.Infof("ack :: pollServiceAdapter :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+		logger.Debugf("ack :: pollServiceAdapter :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 		agent.requestedAckPosition = NullPosition
 	}
 }
@@ -450,7 +450,7 @@ func (agent *ClusteredServiceAgent) terminate() {
 	agent.activeLifecycleCallback = LIFECYCLE_CALLBACK_NONE
 	attempts := 5
 	ackId := agent.getAndIncrementNextAckId()
-	logger.Infof("ack :: terminate :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: terminate :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	for attempts > 0 && !agent.consensusModuleProxy.ack(
 		agent.logPosition,
 		agent.clusterTime,
@@ -461,7 +461,7 @@ func (agent *ClusteredServiceAgent) terminate() {
 		attempts--
 		agent.Idle(0)
 	}
-	logger.Infof("ack :: terminate :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: terminate :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	agent.terminationPosition = NullPosition
 }
 
@@ -539,7 +539,7 @@ func (agent *ClusteredServiceAgent) joinActiveLog(event *activeLogEvent) error {
 	agent.logAdapter.maxLogPosition = event.maxLogPosition
 
 	ackId := agent.getAndIncrementNextAckId()
-	logger.Infof("ack :: joinActiveLog :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: joinActiveLog :: start :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	for !agent.consensusModuleProxy.ack(
 		event.logPosition,
 		agent.clusterTime,
@@ -549,7 +549,7 @@ func (agent *ClusteredServiceAgent) joinActiveLog(event *activeLogEvent) error {
 	) {
 		agent.Idle(0)
 	}
-	logger.Infof("ack :: joinActiveLog :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
+	logger.Debugf("ack :: joinActiveLog :: end :: ackId=%d, clusterTime=%d, clientId=%d, serviceId=%d", ackId, agent.clusterTime, agent.aeronClient.ClientID(), agent.opts.ServiceId)
 	agent.memberId = event.memberId
 	agent.markFile.flyweight.MemberId.Set(agent.memberId)
 
@@ -719,11 +719,11 @@ func (agent *ClusteredServiceAgent) executeAction(
 		}
 
 		ackId := agent.getAndIncrementNextAckId()
-		logger.Infof("ack :: executeAction :: start :: ackId=%d, clusterTime=%d, recordingId=%d, serviceId=%d", ackId, agent.clusterTime, recordingId, agent.opts.ServiceId)
+		logger.Debugf("ack :: executeAction :: start :: ackId=%d, clusterTime=%d, recordingId=%d, serviceId=%d", ackId, agent.clusterTime, recordingId, agent.opts.ServiceId)
 		for !agent.consensusModuleProxy.ack(logPosition, agent.clusterTime, ackId, recordingId, agent.opts.ServiceId) {
 			agent.Idle(0)
 		}
-		logger.Infof("ack :: executeAction :: end :: ackId=%d, clusterTime=%d, recordingId=%d, serviceId=%d", ackId, agent.clusterTime, recordingId, agent.opts.ServiceId)
+		logger.Debugf("ack :: executeAction :: end :: ackId=%d, clusterTime=%d, recordingId=%d, serviceId=%d", ackId, agent.clusterTime, recordingId, agent.opts.ServiceId)
 	}
 }
 
@@ -785,6 +785,7 @@ func (agent *ClusteredServiceAgent) takeSnapshot(logPos int64, leadershipTermId 
 	if _, err := arch.PollForErrorResponse(); err != nil {
 		var archiveErr *archive.ArchiveError
 		if errors.As(err, &archiveErr) {
+			logger.Error("archive error: space storage is at minimum threshold or exhausted")
 			if archiveErr.ErrorCode == archive.ExceptionSpaceStorage {
 				agent.terminate()
 			}


### PR DESCRIPTION
* awaitRecordingCounterAndId should check for NullCounterId instead of NullValue.
* takeSnapshot is missing a check for STORAGE_SPACE, i.e. the agent should terminate if the system is out of disk space. Requires Issue #PE-30 in order to get to the error code from an Archive error. (https://github.com/real-logic/aeron/blob/4ada470c677f355a328a5c26007c0deee46a3b25/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L968)
