### PR TITLE
[Issue-17 and Issue-21 | PE-79 and PE-72] Fix eager connect for Session

### DIFF
--- a/cluster/snapshot_loader.go
+++ b/cluster/snapshot_loader.go
@@ -98,8 +98,7 @@ func (loader *snapshotLoader) onFragment(
 			}
 
 		case codecs.SnapshotMark.SECTION, codecs.SnapshotMark.NullValue:
-			loader.err = fmt.Errorf("unexpected snapshot mark, pos=%d inSnapshot=%v mark=%v", header.Position(), loader.inSnapshot, marker.Mark)
-			loader.isDone = true
+			logger.Debugf("received snapshot mark, pos=%d inSnapshot=%v mark=%v", header.Position(), loader.inSnapshot, marker.Mark)
 		}
 
 	case clientSessionTemplateId:


### PR DESCRIPTION
* Fix eager connect for ClientContainerSession and make it java compat API (`Connect`, `IsClosing`, `MarkClosing`)
* Fix clustered service agent to use ClientContainerSession correctly in `onSessionOpen` and `joinActiveLog`

* Issue-17: Extra egress publications created from follower nodes. Follower node creates egress Publication for each Client session even though those are never used.
* Issue-21: 
  - snapshot_loader eagerly connects egress Publications while state is being restored. Egress should be only connected from onSessionOpen or joinActiveLog.
  - snapshotLoader.onFragment should simply ignore SnapshotMark.SECTION and SnapshotMark.NullValue markers, i.e. it
should not exit.

 PE-79 and PE-72

* https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ContainerClientSession.java
* https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L847-L858
* https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java#L302-L330