### PR TITLE
[Refactor] ConsensusModuleProxy and ClusterServiceAgent

### DIFF
--- a/aeron/logbuffer/logbuffers.go
+++ b/aeron/logbuffer/logbuffers.go
@@ -28,10 +28,11 @@ var logger = logging.MustGetLogger("logbuffers")
 
 // LogBuffers is the struct providing access to the file or files representing the terms containing the ring buffer
 type LogBuffers struct {
-	mmapFiles []*memmap.File
-	buffers   [PartitionCount + 1]atomic.Buffer
-	meta      LogBufferMetaData
-	refCount  int
+	mmapFiles  []*memmap.File
+	buffers    [PartitionCount + 1]atomic.Buffer
+	meta       LogBufferMetaData
+	refCount   int
+	termLength int32
 }
 
 // Wrap is the factory method wrapping the LogBuffers structure around memory mapped file
@@ -42,6 +43,8 @@ func Wrap(fileName string) *LogBuffers {
 	termLength := computeTermLength(int32(logLength))
 
 	checkTermLength(termLength)
+
+	buffers.termLength = termLength
 
 	if logLength < maxSingleMappingSize {
 		mmap, err := memmap.MapExisting(fileName, 0, 0)
@@ -134,4 +137,8 @@ func (logBuffers *LogBuffers) IncRef() int {
 func (logBuffers *LogBuffers) DecRef() int {
 	logBuffers.refCount--
 	return logBuffers.refCount
+}
+
+func (logBuffers *LogBuffers) TermLength() int32 {
+	return logBuffers.termLength
 }

--- a/aeron/publication.go
+++ b/aeron/publication.go
@@ -55,6 +55,7 @@ type Publication struct {
 	positionBitsToShift      int32
 	pubLimit                 Position
 	channelStatusIndicatorID int32
+	termBufferLength         int32
 
 	isClosed atomic.Bool
 	metaData *logbuffer.LogBufferMetaData
@@ -73,6 +74,7 @@ func NewPublication(logBuffers *logbuffer.LogBuffers) *Publication {
 	pub.maxMessageLength = logbuffer.ComputeMaxMessageLength(termBufferCapacity)
 	pub.positionBitsToShift = int32(util.NumberOfTrailingZeroes(uint32(termBufferCapacity)))
 	pub.maxPossiblePosition = int64(termBufferCapacity) * (1 << 31)
+	pub.termBufferLength = logBuffers.TermLength()
 
 	pub.isClosed.Set(false)
 
@@ -83,6 +85,11 @@ func NewPublication(logBuffers *logbuffer.LogBuffers) *Publication {
 	}
 
 	return pub
+}
+
+// TermBufferLength returns the length in bytes for each term partition in the log buffer.
+func (pub *Publication) TermBufferLength() int32 {
+	return pub.termBufferLength
 }
 
 // ChannelStatusID returns the counter used to represent the channel status

--- a/cluster/error.go
+++ b/cluster/error.go
@@ -1,0 +1,29 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+type ClusterError struct {
+	Message string
+}
+
+func (ce *ClusterError) Error() string {
+	return fmt.Sprintf("cluster error: %s", ce.Message)
+}
+
+type ClusterTerminationError struct {
+	Message string
+}
+
+func (cte *ClusterTerminationError) Error() string {
+	return fmt.Sprintf("cluster termination error: %s", cte.Message)
+}
+
+type AgentTerminationError struct {
+	Message string
+}
+
+func (ate *AgentTerminationError) Error() string {
+	return fmt.Sprintf("agent termination error: %s", ate.Message)
+}


### PR DESCRIPTION
Addressing issue-11, issue-14, and issue-20: mainly revolving around errors not being return and check properly due to the way the old go-code was written (follow java convention but didn't return error/checked exception).

We always return an error now whenever possible (minus a few public API for agents) and check and terminate  in the main routine if encountered any fatal exception (most for now except snapshot)