### PR TITLE
[PE-96] Archive Proxy - add java version of offer and offerWithTime, fix tryConnect fail on backpressure

### DIFF
--- a/archive/proxy.go
+++ b/archive/proxy.go
@@ -71,6 +71,7 @@ func (proxy *Proxy) Offer(buffer *atomic.Buffer, offset int32, length int32, res
 // publication. Responses will be processed on the control
 
 // ConnectRequest packet and offer
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L145
 func (proxy *Proxy) ConnectRequest(correlationID int64, responseStream int32, responseChannel string) (bool, error) {
 
 	// Create a packet and send it
@@ -529,6 +530,7 @@ func (proxy *Proxy) MigrateSegmentsRequest(correlationID int64, srcRecordingID i
 }
 
 // AuthConnectRequest packet and offer
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L145
 func (proxy *Proxy) AuthConnectRequest(correlationID int64, responseStream int32, responseChannel string, encodedCredentials []uint8) (bool, error) {
 
 	// Create a packet and send it

--- a/archive/proxy.go
+++ b/archive/proxy.go
@@ -67,28 +67,19 @@ func (proxy *Proxy) Offer(buffer *atomic.Buffer, offset int32, length int32, res
 
 }
 
-// OfferOnce is the real Java Offer
-func (proxy *Proxy) OfferOnce(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) int64 {
-	return proxy.Publication.Offer(buffer, offset, length, reservedValueSupplier)
-}
-
 // From here we have all the functions that create a data packet and send it on the
 // publication. Responses will be processed on the control
 
 // ConnectRequest packet and offer
-func (proxy *Proxy) ConnectRequest(correlationID int64, responseStream int32, responseChannel string) error {
+func (proxy *Proxy) ConnectRequest(correlationID int64, responseStream int32, responseChannel string) (bool, error) {
 
 	// Create a packet and send it
 	bytes, err := codecs.ConnectRequestPacket(proxy.marshaller, proxy.rangeChecking, correlationID, responseStream, responseChannel)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	if ret := proxy.Offer(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil); ret < 0 {
-		return fmt.Errorf("Offer failed: %d", ret)
-	}
-
-	return nil
+	return proxy.OfferWithTimeout(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 }
 
 // CloseSessionRequest packet and offer
@@ -538,19 +529,15 @@ func (proxy *Proxy) MigrateSegmentsRequest(correlationID int64, srcRecordingID i
 }
 
 // AuthConnectRequest packet and offer
-func (proxy *Proxy) AuthConnectRequest(correlationID int64, responseStream int32, responseChannel string, encodedCredentials []uint8) error {
+func (proxy *Proxy) AuthConnectRequest(correlationID int64, responseStream int32, responseChannel string, encodedCredentials []uint8) (bool, error) {
 
 	// Create a packet and send it
 	bytes, err := codecs.AuthConnectRequestPacket(proxy.marshaller, proxy.rangeChecking, correlationID, responseStream, responseChannel, encodedCredentials)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	if ret := proxy.Offer(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil); ret < 0 {
-		return fmt.Errorf("Offer failed: %d", ret)
-	}
-
-	return nil
+	return proxy.OfferWithTimeout(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 }
 
 // ChallengeResponse packet and offer

--- a/archive/proxy_compat.go
+++ b/archive/proxy_compat.go
@@ -2,10 +2,86 @@ package archive
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/logbuffer/term"
 	"github.com/lirm/aeron-go/archive/codecs"
 )
+
+// TODO: should be configurable for Proxy
+const PROXY_DEFAULT_RETRY_ATTEMPTS = 3
+
+// Offer to our request publication with a retry to allow time for the image establishment, some back pressure etc
+func (proxy *Proxy) OfferV1(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) (bool, error) {
+
+	proxy.retryIdleStrategy.Reset()
+	attempts := PROXY_DEFAULT_RETRY_ATTEMPTS
+	var position int64
+	for {
+		position = proxy.Publication.Offer(buffer, offset, length, reservedValueSupplier)
+		if position > 0 {
+			return true, nil
+		}
+
+		if position == aeron.PublicationClosed {
+			return false, NewArchiveError(-1, -1, "Proxy.Offer :: connection to the archive has been closed")
+		}
+
+		if position == aeron.NotConnected {
+			return false, NewArchiveError(-1, -1, "Proxy.Offer :: connection to the archive is no longer available")
+		}
+
+		if position == aeron.MaxPositionExceeded {
+			return false, NewArchiveError(-1, -1, fmt.Sprintf("Proxy.Offer :: offer failed due to max position being reached: term-length=%d", proxy.Publication.TermBufferLength()))
+		}
+
+		attempts--
+		if attempts <= 0 {
+			logger.Debugf("Proxy.Offer :: reached max attempts, offer failed [%d]", position)
+			return false, nil
+		}
+
+		proxy.retryIdleStrategy.Idle(0)
+	}
+}
+
+// OfferWithTimeout ...
+// adapts from https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L1516
+func (proxy *Proxy) OfferWithTimeout(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) (bool, error) {
+	proxy.retryIdleStrategy.Reset()
+
+	deadline := time.Now().Add(proxy.timeout)
+	var position int64
+	for {
+		position = proxy.Publication.Offer(buffer, offset, length, reservedValueSupplier)
+		if position > 0 {
+			return true, nil
+		}
+
+		if position == aeron.PublicationClosed {
+			return false, NewArchiveError(-1, -1, "Proxy.OfferWithTimeout :: connection to the archive has been closed")
+		}
+
+		if position == aeron.MaxPositionExceeded {
+			return false, NewArchiveError(-1, -1, fmt.Sprintf("Proxy.OfferWithTimoeut :: offer failed due to max position being reached: term-length=%d", proxy.Publication.TermBufferLength()))
+		}
+
+		if time.Now().After(deadline) {
+			// Give up, returning the last failure
+			logger.Debugf("Proxy.OfferWithTimeout timing out [%d]", position)
+			return false, nil
+		}
+
+		proxy.retryIdleStrategy.Idle(0)
+	}
+}
+
+// OfferOnce ...
+func (proxy *Proxy) OfferOnce(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) int64 {
+	return proxy.Publication.Offer(buffer, offset, length, reservedValueSupplier)
+}
 
 // ArchiveId Get the id of the archive
 func (proxy *Proxy) ArchiveId(correlationId, controlSessionId int64) (bool, error) {
@@ -14,12 +90,7 @@ func (proxy *Proxy) ArchiveId(correlationId, controlSessionId int64) (bool, erro
 		return false, err
 	}
 
-	ret := proxy.Offer(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
-	if ret < 0 {
-		return false, fmt.Errorf("Offer failed: %d", ret)
-	}
-
-	return ret > 0, nil
+	return proxy.OfferV1(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 }
 
 // TryChallengeResponse ...
@@ -30,9 +101,9 @@ func (proxy *Proxy) TryChallengeResponse(encodedCredentials []uint8, correlation
 		return false, err
 	}
 
-	ret := proxy.Offer(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
+	ret := proxy.OfferOnce(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 	if ret < 0 {
-		return false, fmt.Errorf("Offer failed: %d", ret)
+		logger.Debugf("Proxy.TryChallengeResponse :: Offer failed: %d", ret)
 	}
 
 	return ret > 0, nil
@@ -49,8 +120,7 @@ func (proxy *Proxy) TryConnect(responseChannel string, responseStreamId int32, c
 
 	ret := proxy.OfferOnce(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 	if ret < 0 {
-		return false, fmt.Errorf("Offer failed: %d", ret)
+		logger.Debugf("Proxy.TryConnect :: Offer failed: %d", ret)
 	}
-
 	return ret > 0, nil
 }

--- a/archive/proxy_compat.go
+++ b/archive/proxy_compat.go
@@ -14,6 +14,7 @@ import (
 const PROXY_DEFAULT_RETRY_ATTEMPTS = 3
 
 // Offer to our request publication with a retry to allow time for the image establishment, some back pressure etc
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L1478
 func (proxy *Proxy) OfferV1(buffer *atomic.Buffer, offset int32, length int32, reservedValueSupplier term.ReservedValueSupplier) (bool, error) {
 
 	proxy.retryIdleStrategy.Reset()
@@ -93,7 +94,8 @@ func (proxy *Proxy) ArchiveId(correlationId, controlSessionId int64) (bool, erro
 	return proxy.OfferV1(atomic.MakeBuffer(bytes, len(bytes)), 0, int32(len(bytes)), nil)
 }
 
-// TryChallengeResponse ...
+// TryChallengeResponse Try and send a ChallengeResponse to an archive on its control interface providing the credentials. Only one attempt will be made to offer the request.
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L260
 func (proxy *Proxy) TryChallengeResponse(encodedCredentials []uint8, correlationId, controlSessionId int64) (bool, error) {
 	// Create a packet and send it
 	bytes, err := codecs.ChallengeResponsePacket(proxy.marshaller, proxy.rangeChecking, controlSessionId, correlationId, encodedCredentials)
@@ -109,7 +111,8 @@ func (proxy *Proxy) TryChallengeResponse(encodedCredentials []uint8, correlation
 	return ret > 0, nil
 }
 
-// TryConnect ...
+// TryConnect Try and connect to an archive on its control interface providing the response stream details. Only one attempt will be made to offer the request.
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java#L170
 func (proxy *Proxy) TryConnect(responseChannel string, responseStreamId int32, correlationID int64) (bool, error) {
 
 	// Create a packet and send it


### PR DESCRIPTION
The current version of Proxy has many semantic errors, this is first one of many fixes and refactors

* `OfferV1` -  java like - with maximum number of attempts, also we don't return error on attempt exhaustion
* `OfferWithTimeout` - like go version of Offer but only for connection request.
* `TryConnect` only check once and not return error from offer failed