### PR TITLE
[PE-99] Implement TryClaim semantic for `ConsensusModuleProxy`

### DIFF
--- a/aeron/logbuffer/term/appender.go
+++ b/aeron/logbuffer/term/appender.go
@@ -343,6 +343,10 @@ func (appender *Appender) SetTailTermID(termID int32) {
 	appender.tailCounter.Set(int64(termID) << 32)
 }
 
+func (appender *Appender) TermBuffer() *atomic.Buffer {
+	return appender.termBuffer
+}
+
 func minInt32(v1, v2 int32) int32 {
 	if v1 < v2 {
 		return v1

--- a/aeron/publication_compat.go
+++ b/aeron/publication_compat.go
@@ -1,0 +1,14 @@
+package aeron
+
+import "fmt"
+
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-client/src/main/java/io/aeron/Publication.java#L693
+func (pub *Publication) checkPayloadLength(length int32) {
+	if length < 0 {
+		panic(fmt.Sprintf("invalid length: %d", length))
+	}
+
+	if length > pub.maxPayloadLength {
+		panic(fmt.Sprintf("claim exceeds maxPayloadLength of %d, length=%d", pub.maxPayloadLength, length))
+	}
+}

--- a/cluster/clustered_service_agent.go
+++ b/cluster/clustered_service_agent.go
@@ -1034,7 +1034,7 @@ func (agent *ClusteredServiceAgent) closeClientSession(id int64) bool {
 
 	attempts := 3
 	for attempts > 0 {
-		ok, err := agent.consensusModuleProxy.closeSessionRequest(id)
+		ok, err := agent.consensusModuleProxy.closeSession(id)
 		if err != nil {
 			logger.Errorf("closeClientSession: unable to send closeSessionRequest")
 		}

--- a/cluster/codecs/encoders_compat.go
+++ b/cluster/codecs/encoders_compat.go
@@ -1,0 +1,103 @@
+package codecs
+
+import (
+	"bytes"
+
+	"github.com/lirm/aeron-go/aeron/atomic"
+)
+
+// TODO: Codegen all these
+
+func ScheduleTimerEncoder(
+	marshaller *SbeGoMarshaller,
+	rangeChecking bool,
+	correlationId int64,
+	deadline int64,
+) ([]byte, error) {
+	request := ScheduleTimer{
+		CorrelationId: correlationId,
+		Deadline:      deadline,
+	}
+
+	// Marshal it
+	header := MessageHeader{
+		BlockLength: request.SbeBlockLength(),
+		TemplateId:  request.SbeTemplateId(),
+		SchemaId:    request.SbeSchemaId(),
+		Version:     request.SbeSchemaVersion(),
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := header.Encode(marshaller, buffer); err != nil {
+		return nil, err
+	}
+	if err := request.Encode(marshaller, buffer, rangeChecking); err != nil {
+		return nil, err
+	}
+
+	atomic.MakeBuffer(buffer.Bytes)
+
+	return buffer.Bytes(), nil
+}
+
+func CancelTimerEncoder(
+	marshaller *SbeGoMarshaller,
+	rangeChecking bool,
+	correlationId int64,
+) ([]byte, error) {
+	request := CancelTimer{
+		CorrelationId: correlationId,
+	}
+
+	// Marshal it
+	header := MessageHeader{
+		BlockLength: request.SbeBlockLength(),
+		TemplateId:  request.SbeTemplateId(),
+		SchemaId:    request.SbeSchemaId(),
+		Version:     request.SbeSchemaVersion(),
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := header.Encode(marshaller, buffer); err != nil {
+		return nil, err
+	}
+	if err := request.Encode(marshaller, buffer, rangeChecking); err != nil {
+		return nil, err
+	}
+
+	atomic.MakeBuffer(buffer.Bytes)
+
+	return buffer.Bytes(), nil
+}
+
+func ClusterMembersQueryEncoder(
+	marshaller *SbeGoMarshaller,
+	rangeChecking bool,
+	correlationId int64,
+	extended BooleanTypeEnum,
+) ([]byte, error) {
+	request := ClusterMembersQuery{
+		CorrelationId: correlationId,
+		Extended:      extended,
+	}
+
+	// Marshal it
+	header := MessageHeader{
+		BlockLength: request.SbeBlockLength(),
+		TemplateId:  request.SbeTemplateId(),
+		SchemaId:    request.SbeSchemaId(),
+		Version:     request.SbeSchemaVersion(),
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := header.Encode(marshaller, buffer); err != nil {
+		return nil, err
+	}
+	if err := request.Encode(marshaller, buffer, rangeChecking); err != nil {
+		return nil, err
+	}
+
+	atomic.MakeBuffer(buffer.Bytes)
+
+	return buffer.Bytes(), nil
+}

--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lirm/aeron-go/aeron"
 	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/logbuffer"
 	"github.com/lirm/aeron-go/cluster/codecs"
 )
 
@@ -19,17 +20,21 @@ type consensusModuleProxy struct {
 	rangeChecking bool
 	publication   *aeron.Publication
 	buffer        *atomic.Buffer
+	bufferClaim   logbuffer.Claim
 }
 
 func newConsensusModuleProxy(
 	options *Options,
 	publication *aeron.Publication,
 ) *consensusModuleProxy {
+	var bufferClaim logbuffer.Claim
+	buffer := atomic.MakeBuffer(make([]byte, 500))
 	return &consensusModuleProxy{
 		marshaller:    codecs.NewSbeGoMarshaller(),
 		rangeChecking: options.RangeChecking,
 		publication:   publication,
-		buffer:        atomic.MakeBuffer(make([]byte, 500)),
+		buffer:        buffer,
+		bufferClaim:   bufferClaim,
 	}
 }
 

--- a/cluster/consensus_module_proxy.go
+++ b/cluster/consensus_module_proxy.go
@@ -37,7 +37,7 @@ func newConsensusModuleProxy(
 // publication. Responses will be processed on the control
 
 // ConnectRequest packet and send
-func (proxy *consensusModuleProxy) ack(
+func (proxy *consensusModuleProxy) ackOffer(
 	logPosition int64,
 	timestamp int64,
 	ackID int64,
@@ -62,7 +62,7 @@ func (proxy *consensusModuleProxy) ack(
 	return proxy.offerAndCheck(buffer, 0, buffer.Capacity())
 }
 
-func (proxy *consensusModuleProxy) closeSessionRequest(
+func (proxy *consensusModuleProxy) closeSessionOffer(
 	clusterSessionId int64,
 ) (bool, error) {
 	// Create a packet and send it
@@ -78,14 +78,14 @@ func (proxy *consensusModuleProxy) closeSessionRequest(
 	return proxy.offerAndCheck(buffer, 0, buffer.Capacity())
 }
 
-func (proxy *consensusModuleProxy) scheduleTimer(correlationId int64, deadline int64) (bool, error) {
+func (proxy *consensusModuleProxy) scheduleTimerOffer(correlationId int64, deadline int64) (bool, error) {
 	buf := proxy.initBuffer(scheduleTimerTemplateId, scheduleTimerBlockLength)
 	buf.PutInt64(SBEHeaderLength, correlationId)
 	buf.PutInt64(SBEHeaderLength+8, deadline)
 	return proxy.offerAndCheck(buf, 0, SBEHeaderLength+scheduleTimerBlockLength)
 }
 
-func (proxy *consensusModuleProxy) cancelTimer(correlationId int64) (bool, error) {
+func (proxy *consensusModuleProxy) cancelTimerOffer(correlationId int64) (bool, error) {
 	buf := proxy.initBuffer(cancelTimerTemplateId, cancelTimerBlockLength)
 	buf.PutInt64(SBEHeaderLength, correlationId)
 	return proxy.offerAndCheck(buf, 0, SBEHeaderLength+cancelTimerBlockLength)

--- a/cluster/consensus_module_proxy_compat.go
+++ b/cluster/consensus_module_proxy_compat.go
@@ -1,0 +1,182 @@
+package cluster
+
+import (
+	"github.com/lirm/aeron-go/aeron/atomic"
+	"github.com/lirm/aeron-go/aeron/logbuffer"
+	"github.com/lirm/aeron-go/cluster/codecs"
+)
+
+// -----------------------------------------------------------------------------
+// Java compat implementation and using TryClaim for better performance
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java
+// -----------------------------------------------------------------------------
+
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java#L146
+func (proxy *consensusModuleProxy) ack(
+	logPosition int64,
+	timestamp int64,
+	ackID int64,
+	relevantID int64,
+	serviceID int32,
+) (bool, error) {
+	length := int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.ServiceAck).SbeBlockLength()))
+	position := proxy.publication.TryClaim(length, &proxy.bufferClaim)
+	if position > 0 {
+		// Create a packet and send it
+		bytes, err := codecs.ServiceAckRequestPacket(
+			proxy.marshaller,
+			proxy.rangeChecking,
+			logPosition,
+			timestamp,
+			ackID,
+			relevantID,
+			serviceID,
+		)
+		if err != nil {
+			proxy.bufferClaim.Abort()
+			return false, err
+		}
+
+		proxy.bufferClaim.Buffer().PutBytesArray(proxy.bufferClaim.Offset(), &bytes, 0, length)
+		proxy.bufferClaim.Commit()
+		return true, nil
+	}
+
+	if err := checkResult(position, proxy.publication); err != nil {
+		proxy.bufferClaim.Abort()
+		return false, err
+	}
+	return false, nil
+}
+
+func (proxy *consensusModuleProxy) closeSession(
+	clusterSessionId int64,
+) (bool, error) {
+	length := int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.CloseSession).SbeBlockLength()))
+	position := proxy.publication.TryClaim(length, &proxy.bufferClaim)
+	if position > 0 {
+		bytes, err := codecs.CloseSessionRequestPacket(
+			proxy.marshaller,
+			proxy.rangeChecking,
+			clusterSessionId,
+		)
+		if err != nil {
+			proxy.bufferClaim.Abort()
+			return false, err
+		}
+
+		proxy.bufferClaim.Buffer().PutBytesArray(proxy.bufferClaim.Offset(), &bytes, 0, length)
+		proxy.bufferClaim.Commit()
+		return true, nil
+	}
+
+	if err := checkResult(position, proxy.publication); err != nil {
+		proxy.bufferClaim.Abort()
+		return false, err
+	}
+	return false, nil
+}
+
+func (proxy *consensusModuleProxy) scheduleTimer(correlationId int64, deadline int64) (bool, error) {
+	length := int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.ScheduleTimer).SbeBlockLength()))
+	position := proxy.publication.TryClaim(length, &proxy.bufferClaim)
+	if position > 0 {
+		bytes, err := codecs.ScheduleTimerEncoder(
+			proxy.marshaller,
+			proxy.rangeChecking,
+			correlationId,
+			deadline,
+		)
+		if err != nil {
+			proxy.bufferClaim.Abort()
+			return false, err
+		}
+
+		proxy.bufferClaim.Buffer().PutBytesArray(proxy.bufferClaim.Offset(), &bytes, 0, length)
+		proxy.bufferClaim.Commit()
+		return true, nil
+	}
+
+	if err := checkResult(position, proxy.publication); err != nil {
+		proxy.bufferClaim.Abort()
+		return false, err
+	}
+	return false, nil
+}
+
+func (proxy *consensusModuleProxy) cancelTimer(correlationId int64) (bool, error) {
+	length := int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.CancelTimer).SbeBlockLength()))
+	position := proxy.publication.TryClaim(length, &proxy.bufferClaim)
+	if position > 0 {
+		bytes, err := codecs.CancelTimerEncoder(
+			proxy.marshaller,
+			proxy.rangeChecking,
+			correlationId,
+		)
+		if err != nil {
+			proxy.bufferClaim.Abort()
+			return false, err
+		}
+
+		proxy.bufferClaim.Buffer().PutBytesArray(proxy.bufferClaim.Offset(), &bytes, 0, length)
+		proxy.bufferClaim.Commit()
+		return true, nil
+	}
+
+	if err := checkResult(position, proxy.publication); err != nil {
+		proxy.bufferClaim.Abort()
+		return false, err
+	}
+	return false, nil
+}
+
+func (proxy *consensusModuleProxy) clusterMembersQuery(correlationId int64) (bool, error) {
+	length := int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.ClusterMembersQuery).SbeBlockLength()))
+	position := proxy.publication.TryClaim(length, &proxy.bufferClaim)
+	if position > 0 {
+		bytes, err := codecs.ClusterMembersQueryEncoder(
+			proxy.marshaller,
+			proxy.rangeChecking,
+			correlationId,
+			codecs.BooleanType.TRUE,
+		)
+		if err != nil {
+			proxy.bufferClaim.Abort()
+			return false, err
+		}
+
+		proxy.bufferClaim.Buffer().PutBytesArray(proxy.bufferClaim.Offset(), &bytes, 0, length)
+		proxy.bufferClaim.Commit()
+		return true, nil
+	}
+
+	if err := checkResult(position, proxy.publication); err != nil {
+		proxy.bufferClaim.Abort()
+		return false, err
+	}
+	return false, nil
+}
+
+// TODO: fix proper constant and namespace
+var SESSION_HEADER_LENGTH = int32(new(codecs.MessageHeader).EncodedLength() + int64(new(codecs.SessionMessageHeader).SbeBlockLength()))
+
+// https://github.com/real-logic/aeron/blob/release/1.46.x/aeron-cluster/src/main/java/io/aeron/cluster/service/ConsensusModuleProxy.java#L131
+func (proxy *consensusModuleProxy) TryClaim(length int32, bufferClaim *logbuffer.Claim, sessionHeader *atomic.Buffer) (int64, error) {
+	position := proxy.publication.TryClaim(length, bufferClaim)
+	if position > 0 {
+		bufferClaim.Buffer().PutBytes(int32(logbuffer.DataFrameHeader.Length), sessionHeader, 0, SESSION_HEADER_LENGTH)
+	} else {
+		if err := checkResult(position, proxy.publication); err != nil {
+			bufferClaim.Abort()
+			return NullValue, err
+		}
+	}
+
+	return position, nil
+}
+
+func (proxy *consensusModuleProxy) Close() {
+	if err := proxy.publication.Close(); err != nil {
+		logger.Errorf("failed to close publication: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lirm/aeron-go
 
-go 1.20
+go 1.23.0
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=


### PR DESCRIPTION
`TryClaim` try to claim a range in the publication log into which a message can be written with zero copy semantics (can be stored and reused to avoid allocation), which is way more efficient than current **Offer** which always uses **500 bytes** in `ConsensusModuleProxy`, and bloating and take up space in the logbuffer with every offer (hit esp harder in case of retry); whereas `tryClaim` is more suitable for the way smaller of 44 bytes size for small messages + pre-allocation in logbuffer.


* [Logbuffer|Appender] Add missing methods and fix TermOffset func
* [publication] fix missing check semantic for TryClaim
* [cluster/codecs] Add proper semantic encoder codecs for ScheduleTimer, CancelTimer, Ack, and missing ClusterMembersQuery
* [consensusModuleProxy] rename old semantic to have Offer suffix i.e ack -> ackOffer
* [consensusModuleProxy] switch to use tryClaim for optimized performance
* [go] Upgrade to 1.23.0 to allow usage of min Int64
